### PR TITLE
Copy scm-source.json into the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,6 @@ RUN \
   touch /var/log/ghe-delete-instuck-progress.log && \
   chown -R application: /var/log/ghe-delete-instuck-progress.log
 
+COPY scm-source.json /
+
 CMD ["/backup/final-docker-cmd.sh"]


### PR DESCRIPTION
In the readme there is an instruction to generate `scm-source.json`, but it never gets added to the docker image.
