### PR TITLE
3.6.3-15 stups python base docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/python:3.6.2-14
+FROM registry.opensource.zalan.do/stups/python:3.6.3-15
 MAINTAINER lothar.schulz@zalando.de
 
 # folder structure and user


### PR DESCRIPTION
fix #78 

use 3.6.3-15 (https://registry.opensource.zalan.do/teams/stups/artifacts/python/tags)