### PR TITLE
replace-convert-properties.sh adapted to backup folder

### DIFF
--- a/final-docker-cmd.sh
+++ b/final-docker-cmd.sh
@@ -10,7 +10,7 @@ if [ -z "$REGION" ]
 then
   REGION="eu-west-1"
 fi
-./replace-convert-properties.sh "###REGION###" "$REGION" /kms/convert-kms-private-ssh-key.sh
+/backup/replace-convert-properties.sh "###REGION###" "$REGION" /kms/convert-kms-private-ssh-key.sh
 /kms/convert-kms-private-ssh-key.sh
 # do the actual backups via cron
 # everything in sbin directory needs to be executed as privileged user


### PR DESCRIPTION
fix

```
$ zkubectl logs statefulset-ghe-backup-0
/backup/final-docker-cmd.sh: line 13: ./replace-convert-properties.sh: No such file or directory
```