### PR TITLE
run as root (non-privileged mode compatibility); push PR images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,9 @@ MAINTAINER team-code@zalando.de
 RUN \
 # read package lists
   apt-get update -y && \
-  apt-get install -y sudo && \
-# create application user
-  useradd -d /backup -u 998 -o -c "application user" application && \
-# allow su
-  echo "application ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/application && \
-  chmod 0440 /etc/sudoers.d/application && \
 # update w/ latest security patches
 # install python pip3 & english, git, screen etc
-  apt-get install -y --no-install-recommends unattended-upgrades python3 python3-dev && \
-  apt-get install -y --no-install-recommends python3-pip python3-yaml && \
+  apt-get install -y --no-install-recommends unattended-upgrades python3 python3-dev python3-pip python3-yaml && \
   apt-get install -y --no-install-recommends git && \
   apt-get install -y --no-install-recommends ssh && \
   apt-get install -y --no-install-recommends bash && \
@@ -59,21 +52,15 @@ COPY replace-convert-properties.sh /backup/replace-convert-properties.sh
 
 RUN \
 # change mode of files
-  chown -R application: /backup && \
-  chown -R application: /kms && \
-  chown -R application: /delete-instuck-backups && \
-  chown -R application: /start_backup.sh && \
-  chmod 0700 /kms/extract_decrypt_kms.py && \
-  chmod 0700 /kms/convert-kms-private-ssh-key.sh && \
   chmod 0644 /etc/cron.d/ghe-backup && \
-  chmod 0700 /delete-instuck-backups/delete_instuck_progress.py && \
-  chmod 0700 /start_backup.sh && \
-  chmod 0700 /backup/replace-convert-properties.sh && \
-  chmod 0700 /backup/final-docker-cmd.sh
+  chmod +x /kms/extract_decrypt_kms.py && \
+  chmod +x /kms/convert-kms-private-ssh-key.sh && \
+  chmod +x /delete-instuck-backups/delete_instuck_progress.py && \
+  chmod +x /start_backup.sh && \
+  chmod +x /backup/replace-convert-properties.sh && \
+  chmod +x /backup/final-docker-cmd.sh
 
-USER application
+USER root
 
-# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#user mentions to avoid sudo,
-# however cron as part of the final-docker-cmd.sh has to run as
+# cron must run as root
 CMD "/backup/final-docker-cmd.sh"
-

--- a/cron-ghe-backup
+++ b/cron-ghe-backup
@@ -1,5 +1,5 @@
 # ghe prod backups
-0 */2 * * 1-6 application find /data/ghe-production-data/ -maxdepth 2 -mindepth 2 -name incomplete -atime +1  -printf "%h\0" | xargs -0 rm -Rf
-17 3,9,12,13,15,17,18,21 * * 1-6 application /start_backup.sh
-17 9,15,21 * * 7 application /start_backup.sh
-55 7,8,9,10,11,12,13,14,15,16,17,18,19 * * 1-6 application python3 /delete-instuck-backups/delete_instuck_progress.py 2>&1 > /var/log/application.log
+0 */2 * * 1-6 root find /data/ghe-production-data/ -maxdepth 2 -mindepth 2 -name incomplete -atime +1  -printf "%h\0" | xargs -0 rm -Rf > /var/log/application.log 2>&1
+17 3,9,12,13,15,17,18,21 * * 1-6 root /start_backup.sh > /var/log/application.log 2>&1
+17 9,15,21 * * 7 root /start_backup.sh > /var/log/application.log 2>&1
+55 7,8,9,10,11,12,13,14,15,16,17,18,19 * * 1-6 root python3 /delete-instuck-backups/delete_instuck_progress.py > /var/log/application.log 2>&1

--- a/cron-ghe-backup-k8s-sample
+++ b/cron-ghe-backup-k8s-sample
@@ -1,4 +1,4 @@
 # ghe bus k8s prod backups
-21 10,13,16,19,22 * * 1-6 application /start_backup.sh
-21 10,16,22 * * 7 application /start_backup.sh
-57 7,8,9,10,11,12,13,14,15,16,17,18,19 * * 1-6 application python3 /delete-instuck-backups/delete_instuck_progress.py 2>&1 > /var/log/application.log
+21 10,13,16,19,22 * * 1-6 root /start_backup.sh
+21 10,16,22 * * 7 root /start_backup.sh
+57 7,8,9,10,11,12,13,14,15,16,17,18,19 * * 1-6 root python3 /delete-instuck-backups/delete_instuck_progress.py 2>&1 > /var/log/application.log

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,30 +3,26 @@ pipeline:
   - id: build
     overlay: ci/python
     type: script
-    #when:
-    #  branch: master
     commands:
       - desc: "setup the environment"
         cmd: |
           apt-get update
-          apt-get install -y python3-dev python-pip python3-pip
-          curl -sSL https://delivery.cloud.zalando.com/utils/ensure-docker | sh
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+          apt-get install -qy python3-dev python-pip python3-pip
+          update-alternatives --install /usr/bin/python python /usr/bin/python3 10
           pip install -r python/requirements.txt
       - desc: "run tests"
         cmd: |
           nosetests -w python
       - desc: "build and push docker images"
         cmd: |
-          PIERONE_NAMESPACE=pierone.stups.zalan.do/machinery
-          BASE_IMAGE=$PIERONE_NAMESPACE/ghe-backup
-          IMAGE=$BASE_IMAGE:cdp-${CDP_BUILD_VERSION}
-          CACHE_IMAGE=$BASE_IMAGE:latest
-          docker build --cache-from $CACHE_IMAGE -t $CACHE_IMAGE -t $IMAGE -f Dockerfile .
-          #docker build -t $IMAGE -f Dockerfile .
-          if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
-            docker push $IMAGE
-            echo "$IMAGE pushed"
+          BASE_IMAGE="pierone.stups.zalan.do/machinery/ghe-backup"
+          if [[ "${CDP_TARGET_BRANCH}" == "master" && -z "${CDP_PULL_REQUEST_NUMBER}" ]]; then
+              IMAGE="${BASE_IMAGE}:cdp-${CDP_BUILD_VERSION}"
           else
-            echo "Image not pushed because the build is not a push to master"
+              IMAGE="${BASE_IMAGE}-test:cdp-${CDP_BUILD_VERSION}"
           fi
+
+          docker build --cache-from "${BASE_IMAGE}:latest" -t "${IMAGE}" -f Dockerfile .
+
+          docker push "${IMAGE}"
+          echo "${IMAGE} pushed"

--- a/final-docker-cmd.sh
+++ b/final-docker-cmd.sh
@@ -3,16 +3,19 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-sudo ln -sf /proc/$$/fd/1 /var/log/application.log
-python3 /delete-instuck-backups/delete_instuck_progress.py 2>&1
+ln -sf /proc/$$/fd/1 /var/log/application.log
+
+python3 /delete-instuck-backups/delete_instuck_progress.py
 REGION=$(curl http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
 # fall back to Ireland AWS region if REGION is unset or set to the empty string
 if [ -z "$REGION" ]
 then
   REGION="eu-west-1"
 fi
+
 /backup/replace-convert-properties.sh "###REGION###" "$REGION" /kms/convert-kms-private-ssh-key.sh
 /kms/convert-kms-private-ssh-key.sh
+
 # do the actual backups via cron
 # everything in sbin directory needs to be executed as privileged user
-sudo /usr/sbin/cron -f
+/usr/sbin/cron -f

--- a/start_backup.sh
+++ b/start_backup.sh
@@ -3,13 +3,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# exit if the same process runs already
 pidof -o $$ -x "$0" >/dev/null 2>&1 && exit 1
-if [ 0  ==  $(stat -c '%u' /data) ]
-then
-    sudo chown -R application: /data
-fi
-if [ ! -d "/data/ghe-production-data/" ]
-then
+
+if [ ! -d "/data/ghe-production-data/" ]; then
     mkdir -p /data/ghe-production-data/
 fi
-/backup/backup-utils/bin/ghe-backup 2>&1 > /var/log/application.log
+/backup/backup-utils/bin/ghe-backup


### PR DESCRIPTION
Run ghe-backup as root in order to allow to run ghe-backup in a non-privileged container mode (internal issue [#1528](https://github.bus.zalan.do/machinery/machinery-planning/issues/1528)) and builds/pushes PR images to Pierone.